### PR TITLE
@jeongin - 0909 가장 먼 노드

### DIFF
--- a/이정인/0909.py
+++ b/이정인/0909.py
@@ -1,0 +1,19 @@
+from collections import deque
+
+def solution(n, edge):
+    routes = dict()
+    for e1, e2 in edge:
+        routes.setdefault(e1, []).append(e2)
+        routes.setdefault(e2, []).append(e1)
+        
+    q = deque([[1, 0]]) # node number, depth
+    check = [-1]*(n+1)
+    while q:
+        index, depth = q.popleft()
+        check[index] = depth
+        for i in routes[index]:
+            if check[i]==-1:
+                check[i] = 0
+                q.append([i, depth+1])
+        depth += 1
+    return check.count(max(check))


### PR DESCRIPTION
bfs 공부가 시급하네요 
### 알게된 점 

1.  `for e1, e2 in edge:`
   for 문 이런식으로 써서 이중 배열 값 각각 불러올 수도 있구나 

2. `setdefault(key,value)` : key 이미 있으면 key 값 반환 없으면 value 반환 
   ```python
   for e1, e2 in edge: 
     routes.setdefault(e1, []).append(e2)
     routes.setdefault(e2, []).append(e1)
   #print(routes)
   #{3: [6, 4, 2, 1], 6: [3], 4: [3, 2], 2: [3, 1, 4, 5], 1: [3, 2], 5: [2]}
   ```
   각 노드 별로 연결된 노드를 깔끔하게 정리 할 수 있다 

3. 일반 list의 pop(0) 가 아닌 deque.popleft를 사용하면  시행횟수를 줄일 수 있음

4. 방문한 노드 체크 

   - -1로 전부 초기화

     `check = [-1]*(n+1)`

5. `check.count(max(check))`
   최대 값 리턴 